### PR TITLE
Remove ruff.useDetectRuffCommand setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,6 @@
 Plug 'yaegassy/coc-ruff', {'do': 'yarn install --frozen-lockfile'}
 ```
 
-## Note
-
-The `ruff` command used by `ruff-lsp` uses the `ruff` command installed with the `ruff-lsp` dependency.
-
-To use the `ruff` command installed in the virtual environment of a project created by `venv`, `poetry`, etc., `ruff.path` must be set to an absolute path.
-
-`coc-ruff` adds the feature to automatically detect ruff commands in the execution environment and use them in `ruff-lsp`.
-
-If you do not need this feature, set `ruff.useDetectRuffCommand` to `false`.
-
-**coc-settings.json**:
-
-```jsonc
-{
-  "ruff.useDetectRuffCommand": false
-}
-```
-
 ## Order of detection of ruff-lsp used by extensions
 
 `coc-ruff` detects and starts `ruff-lsp` in the following priority order.
@@ -61,7 +43,6 @@ To use the built-in installation feature, execute the following command.
 ## Configuration options
 
 - `ruff.enable`: Enable coc-ruff extension, default: `true`
-- `ruff.useDetectRuffCommand`: Automatically detects the ruff command in the execution environment and sets `ruff.path`, default: `true`
 - `ruff.serverPath`: Custom path to the `ruff-lsp` command. If not set, the `ruff-lsp` command found in the current Python environment or in the venv environment created for the extension will be used, default: `""`
 - `ruff.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
 - `ruff.trace.server`: Traces the communication between coc.nvim and the ruff-lsp, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -76,11 +76,6 @@
           "default": true,
           "description": "Enable coc-ruff extension"
         },
-        "ruff.useDetectRuffCommand": {
-          "type": "boolean",
-          "default": true,
-          "description": "Automatically detects the ruff command in the execution environment and sets `ruff.path`."
-        },
         "ruff.serverPath": {
           "type": "string",
           "default": "",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,5 @@
 import { LanguageClient, LanguageClientOptions, ServerOptions, workspace } from 'coc.nvim';
 
-import which from 'which';
-
 export function createLanguageClient(command: string) {
   const serverOptions: ServerOptions = {
     command,
@@ -49,14 +47,5 @@ function convertFromWorkspaceConfigToInitializationOptions() {
 
 function getInitializationOptions() {
   const initializationOptions = convertFromWorkspaceConfigToInitializationOptions();
-
-  // MEMO: Custom Feature
-  if (workspace.getConfiguration('ruff').get<boolean>('useDetectRuffCommand')) {
-    const envRuffCommandPath = which.sync('ruff', { nothrow: true });
-    if (envRuffCommandPath) {
-      initializationOptions.settings.path = [envRuffCommandPath];
-    }
-  }
-
   return initializationOptions;
 }


### PR DESCRIPTION
Since ruff-lsp v0.0.18, this feature has been added to the main body, so this setting on the extension side will be removed.

- <https://github.com/charliermarsh/ruff-lsp/releases/tag/v0.0.18>