### PR TITLE
Disable documentFormatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
           "default": true,
           "description": "Enable coc-ruff extension"
         },
+        "ruff.disableDocumentFormatting": {
+          "type": "boolean",
+          "default": true,
+          "description": "Disable document formatting only."
+        },
         "ruff.serverPath": {
           "type": "string",
           "default": "",

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,6 +8,7 @@ export function createLanguageClient(command: string) {
   const clientOptions: LanguageClientOptions = {
     documentSelector: ['python'],
     initializationOptions: getInitializationOptions(),
+    disabledFeatures: getLanguageClientDisabledFeatures(),
   };
 
   const client = new LanguageClient('ruff', 'ruff-lsp', serverOptions, clientOptions);
@@ -48,4 +49,15 @@ function convertFromWorkspaceConfigToInitializationOptions() {
 function getInitializationOptions() {
   const initializationOptions = convertFromWorkspaceConfigToInitializationOptions();
   return initializationOptions;
+}
+
+function getLanguageClientDisabledFeatures() {
+  const r: string[] = [];
+  if (getConfigDisableDocumentFormatting()) r.push('documentFormatting');
+
+  return r;
+}
+
+function getConfigDisableDocumentFormatting() {
+  return workspace.getConfiguration('ruff').get<boolean>('disableDocumentFormatting', true);
 }


### PR DESCRIPTION
In ruff-lsp v0.0.18, textDocument/formatting was added, but there is a problem.

Error when running formatters such as black provided by coc-pyright.

Therefore, in coc-ruff, change it so that textDocument/formatting does not work.