### PR TITLE
feat: add autoFixOnSave feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Plug 'yaegassy/coc-ruff', {'do': 'yarn install --frozen-lockfile'}
 
 ## Note
 
+### Detecting the "ruff" command from the execution environment
+
 The `ruff` command used by `ruff-lsp` uses the `ruff` command installed with the `ruff-lsp` dependency.
 
 To use the `ruff` command installed in the virtual environment of a project created by `venv`, `poetry`, etc., `ruff.path` must be set to an absolute path.
@@ -35,6 +37,20 @@ If you do not need this feature, set `ruff.useDetectRuffCommand` to `false`.
 ```jsonc
 {
   "ruff.useDetectRuffCommand": false
+}
+```
+
+### Auto-fixing
+
+Auto-fixing can be executed via the `ruff.executeAutofix` command or CodeAction.
+
+Set `ruff.autoFixOnSave` setting to `true` if you also want auto-fixing to be performed when the file is saved.
+
+**coc-settings.json**:
+
+```jsonc
+{
+  "ruff.autoFixOnSave": true
 }
 ```
 
@@ -63,6 +79,7 @@ To use the built-in installation feature, execute the following command.
 - `ruff.enable`: Enable coc-ruff extension, default: `true`
 - `ruff.disableHover`: Disable hover only, default: `false`
 - `ruff.useDetectRuffCommand`: Automatically detects the ruff command in the execution environment and sets `ruff.path`, default: `true`
+- `ruff.autoFixOnSave`: Turns auto fix on save on or off, default: `false`
 - `ruff.serverPath`: Custom path to the `ruff-lsp` command. If not set, the `ruff-lsp` command found in the current Python environment or in the venv environment created for the extension will be used, default: `""`
 - `ruff.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
 - `ruff.trace.server`: Traces the communication between coc.nvim and the ruff-lsp, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
           "default": true,
           "description": "Automatically detects the ruff command in the execution environment and sets `ruff.path`."
         },
+        "ruff.autoFixOnSave": {
+          "type": "boolean",
+          "default": false,
+          "description": "Turns auto fix on save on or off."
+        },
         "ruff.serverPath": {
           "type": "string",
           "default": "",

--- a/src/features/autoFixOnSave.ts
+++ b/src/features/autoFixOnSave.ts
@@ -1,0 +1,46 @@
+import { commands, LanguageClient, TextEdit, workspace } from 'coc.nvim';
+
+type RuffDiagnosticsDataType = {
+  fix: {
+    message: string;
+    edit: TextEdit;
+  } | null;
+  noqa_row: any | null;
+};
+
+export async function register(client: LanguageClient) {
+  await client.onReady();
+
+  if (!workspace.getConfiguration('ruff').get<boolean>('autoFixOnSave', false)) return;
+
+  workspace.registerAutocmd({
+    request: true,
+    event: 'BufWritePre',
+    arglist: [`+expand('<abuf>')`],
+    callback: async () => {
+      const { document } = await workspace.getCurrentState();
+
+      if (!client.diagnostics) return;
+
+      const currentDiags = client.diagnostics.get(document.uri);
+      if (!currentDiags) return;
+
+      let existsFix = false;
+
+      for (const d of currentDiags) {
+        if (d.source !== 'Ruff') continue;
+        if (!('data' in d)) continue;
+
+        const data = d.data as RuffDiagnosticsDataType;
+        if (typeof data.fix === 'object') {
+          existsFix = true;
+          break;
+        }
+      }
+
+      if (existsFix) {
+        commands.executeCommand('ruff.executeAutofix');
+      }
+    },
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import * as builtinInstallServerCommandFeature from './commands/builtinInstallSe
 import * as executeAutofixCommandFeature from './commands/executeAutofix';
 import * as executeOrganizeImportsCommandFeature from './commands/executeOrganizeImports';
 import * as restartCommandFeature from './commands/restart';
+import * as autoFixOnSaveFeature from './features/autoFixOnSave';
 import { getRuffLspPath } from './tool';
 
 let client: LanguageClient | undefined;
@@ -36,4 +37,5 @@ export async function activate(context: ExtensionContext): Promise<void> {
   executeAutofixCommandFeature.activate(context, client);
   executeOrganizeImportsCommandFeature.activate(context, client);
   restartCommandFeature.activate(context, client);
+  autoFixOnSaveFeature.register(client);
 }


### PR DESCRIPTION
## Description

We have added a feature to run the auto-fix command when the file is saved. (coc-eslint like)

close #10

## Add configration

- `ruff.autoFixOnSave`: Turns auto fix on save on or off, default: `false`

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/235410635-368f3120-1b0e-4374-a6b3-7c2ed3d4f258.mp4
