### PR TITLE
feat: ruff format (DocumentFormatting) feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ If you do not need this feature, set `ruff.useDetectRuffCommand` to `false`.
 }
 ```
 
+### Format (DocumentFormatting)
+
+The [black](https://github.com/psf/black) equivalent formatting feature has been added to `ruff`. To enable this feature in `coc-ruff`, please follow the steps below:
+
+1. Please set `ruff.enableExperimentalFormatter` to `true`.
+1. If you are using other Python-related coc-extensions alongside` coc-ruff`, please disable the formatting feature of those coc-extensions.
+   - e.g. `coc-pyright`: 
+     - Please set `python.formatting.provider` to `none`.
+
+---
+
+**coc-settings.json**:
+
+```jsonc
+{
+  "ruff.enableExperimentalFormatter": true,
+  "python.formatting.provider": "none"
+}
+```
+
 ### Auto-fixing
 
 Auto-fixing can be executed via the `ruff.executeAutofix` command or CodeAction.

--- a/package.json
+++ b/package.json
@@ -82,11 +82,6 @@
           "default": true,
           "description": "Enable coc-ruff extension"
         },
-        "ruff.disableDocumentFormatting": {
-          "type": "boolean",
-          "default": true,
-          "description": "Disable document formatting only."
-        },
         "ruff.disableHover": {
           "type": "boolean",
           "default": false,
@@ -207,6 +202,12 @@
           "default": true,
           "description": "Whether to display Quick Fix actions to disable rules via `noqa` suppression comments.",
           "scope": "window",
+          "type": "boolean"
+        },
+        "ruff.enableExperimentalFormatter": {
+          "default": false,
+          "markdownDescription": "Controls whether Ruff registers as capable of code formatting.",
+          "scope": "machine",
           "type": "boolean"
         },
         "ruff.trace.server": {


### PR DESCRIPTION
## Description

The [black](https://github.com/psf/black) equivalent formatting feature has been added to `ruff`. To enable this feature in `coc-ruff`, please follow the steps below:

1. Please set `ruff.enableExperimentalFormatter` to `true`.
1. If you are using other Python-related coc-extensions alongside` coc-ruff`, please disable the formatting feature of those coc-extensions.
   - e.g. `coc-pyright`: 
     - Please set `python.formatting.provider` to `none`.

---

**coc-settings.json**:

```jsonc
{
  "ruff.enableExperimentalFormatter": true,
  "python.formatting.provider": "none"
}
```

## Add config

- `ruff.enableExperimentalFormatter`

