### PR TITLE
feat: native server feature (`ruff.nativeServer`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ If you do not need this feature, set `ruff.useDetectRuffCommand` to `false`.
 }
 ```
 
+## [EXPERIMENTAL] Enabling the Rust-based language server
+
+To use the new Rust-based language server (ruff server), you'll need to enable the `ruff.nativeServer` setting in the coc-settings.json:
+
+```jsonc
+{
+  "ruff.nativeServer": true
+}
+```
+
+In coc-ruff, the ruff binary is detected from the runtime environment (PATH) by default to start the native server. If you want to specify a custom ruff binary path, please set ruff.nativeBinaryPath.
+
+```jsonc
+{
+  "ruff.nativeBinaryPath": "/path/to/ruff"
+}
+```
+
 ### Format (DocumentFormatting)
 
 The [black](https://github.com/psf/black) equivalent formatting feature has been added to `ruff`. This feature is enabled by default in `ruff-lsp` "v0.0.42" and later.
@@ -109,6 +127,8 @@ To use the built-in installation feature, execute the following command.
 ## Configuration options
 
 - `ruff.enable`: Enable coc-ruff extension, default: `true`
+- `ruff.nativeServer`: Use the integrated Rust-based language server, available now in Beta, default: `false`
+- `ruff.nativeBinaryPath`: Custom path for the `ruff` binary when using the native server. If no value is set, the `ruff` command will be detected from the runtime environment, default: `false`
 - `ruff.disableDocumentFormatting`: Disable document formatting only, default: `false`
 - `ruff.disableHover`: Disable hover only, default: `false`
 - `ruff.useDetectRuffCommand`: Automatically detects the ruff command in the execution environment and sets `ruff.path`, default: `true`

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.17",
+    "@types/semver": "^7.5.8",
     "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
@@ -105,6 +106,16 @@
           "type": "boolean",
           "default": false,
           "description": "Turns auto fix on save on or off."
+        },
+        "ruff.nativeServer": {
+          "default": false,
+          "description": "Use the integrated Rust-based language server, available now in Beta.",
+          "type": "boolean"
+        },
+        "ruff.nativeBinaryPath": {
+          "type": "string",
+          "default": "",
+          "description": "Custom path for the `ruff` binary when using the native server. If no value is set, the `ruff` command will be detected from the runtime environment."
         },
         "ruff.serverPath": {
           "type": "string",
@@ -306,6 +317,8 @@
     ]
   },
   "dependencies": {
+    "semver": "^7.6.2",
     "toml": "^3.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,32 @@
 import { LanguageClient, LanguageClientOptions, ServerOptions, workspace } from 'coc.nvim';
+import { RUFF_SERVER_CMD, RUFF_SERVER_REQUIRED_ARGS } from './constant';
 
 import which from 'which';
+
+export function createNativeServerClient(command: string) {
+  const settings = workspace.getConfiguration('ruff');
+  const newEnv = { ...process.env };
+  const args = [RUFF_SERVER_CMD, ...RUFF_SERVER_REQUIRED_ARGS];
+
+  const serverOptions: ServerOptions = {
+    command,
+    args,
+    options: { env: newEnv },
+  };
+
+  if (settings.enableExperimentalFormatter) {
+    newEnv.RUFF_EXPERIMENTAL_FORMATTER = '1';
+  }
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: ['python'],
+    initializationOptions: getInitializationOptions(),
+    disabledFeatures: getLanguageClientDisabledFeatures(),
+  };
+
+  const client = new LanguageClient('ruff', 'ruff native server', serverOptions, clientOptions);
+  return client;
+}
 
 export function createLanguageClient(command: string) {
   const settings = workspace.getConfiguration('ruff');

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -23,3 +23,6 @@ function getPackageVersion(name: string) {
 }
 
 export const RUFF_LSP_VERSION = getPackageVersion('ruff-lsp');
+
+export const RUFF_SERVER_CMD = 'server';
+export const RUFF_SERVER_REQUIRED_ARGS = ['--preview'];

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -4,6 +4,12 @@ import fs from 'fs';
 import path from 'path';
 import which from 'which';
 
+import child_process from 'child_process';
+import util from 'util';
+import semver from 'semver';
+
+const exec = util.promisify(child_process.exec);
+
 export function getPythonPath(): string {
   let pythonPath = workspace.getConfiguration('ruff').get<string>('builtin.pythonPath', '');
   if (pythonPath) {
@@ -53,4 +59,47 @@ export function getRuffLspPath(context: ExtensionContext) {
   }
 
   return ruffLspPath;
+}
+
+export async function getRuffBinaryPath() {
+  // MEMO: Priority to detect ruff binary
+  //
+  // 1. ruff.nativeBinaryPath setting
+  // 2. current environment
+
+  // 1
+  let rufrBinaryPath = workspace.getConfiguration('ruff').get('nativeBinaryPath', '');
+  if (!rufrBinaryPath) {
+    // 2
+    rufrBinaryPath = which.sync('ruff', { nothrow: true }) || '';
+  }
+
+  // check supported version
+  //if (rufrBinaryPath) {
+  //  const versionStr = await getToolVersion(rufrBinaryPath);
+
+  //  if (!versionStr) return '';
+  //  if (!isRuffNativeServerSupported(versionStr)) return '';
+  //}
+
+  return rufrBinaryPath;
+}
+
+async function getToolVersion(command: string): Promise<string | undefined> {
+  const versionCmd = `${command} --version`;
+
+  try {
+    const { stdout } = await exec(versionCmd);
+    return stdout;
+  } catch (error) {
+    return undefined;
+  }
+}
+
+function isRuffNativeServerSupported(versionStr: string): boolean {
+  const parsedSemver = semver.parse(versionStr);
+  if (parsedSemver) {
+    return semver.gte(parsedSemver.version, '0.4.8');
+  }
+  return true;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,6 +228,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.1.tgz#0480eeb7221eb9bc398ad7432c9d7e14b1a5a367"
   integrity sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==
 
+"@types/semver@^7.5.8":
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+
 "@types/which@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.1.tgz#27ecd67f915b7c3d6ba552135bb1eecd66e63501"
@@ -1081,6 +1086,11 @@ semver@^7.5.4:
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.2:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
+  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Overview

### Enabling the Rust-based language server

To use the new Rust-based language server (ruff server), you'll need to enable the `ruff.nativeServer` setting in the coc-settings.json:

```jsonc
{
  "ruff.nativeServer": true
}
```

In coc-ruff, the ruff binary is detected from the runtime environment (PATH) by default to start the native server. If you want to specify a custom ruff binary path, please set ruff.nativeBinaryPath.

```jsonc
{
  "ruff.nativeBinaryPath": "/path/to/ruff"
}
```

